### PR TITLE
Added different default font for carets

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ void (function (root, factory) {
 
   injectStyle('details-polyfill-style',
     'html.no-details ' + DETAILS + ':not([open]) > :not(' + SUMMARY + ') { display: none; }\n' +
-    'html.no-details ' + DETAILS + ' > ' + SUMMARY + ':before { content: "\u25b6"; display: inline-block; font-size: .8em; width: 1.5em; }\n' +
+    'html.no-details ' + DETAILS + ' > ' + SUMMARY + ':before { content: "\u25b6"; font-family: "Segoe UI Symbol"; display: inline-block; font-size: .8em; width: 1.5em; }\n' +
     'html.no-details ' + DETAILS + '[open] > ' + SUMMARY + ':before { content: "\u25bc"; }')
 
   /*


### PR DESCRIPTION
There is an issue with the way Edge displays "black right pointing triangle" character that is used for "closed" state caret. Basically with default font, Edge displays blue square with caret inside. The "black down pointing triangle" is unaffected by this issue.

See:
https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11844964/
https://codepen.io/prometheusTX/pen/vmZzxG