### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ void (function (root, factory) {
   window.addEventListener('click', clickHandler)
 
   injectStyle('details-polyfill-style',
+    'html.no-details ' + DETAILS + ' { display: block; }\n' +              
     'html.no-details ' + DETAILS + ':not([open]) > :not(' + SUMMARY + ') { display: none; }\n' +
     'html.no-details ' + DETAILS + ' > ' + SUMMARY + ':before { content: "\u25b6"; display: inline-block; font-size: .8em; width: 1.5em; }\n' +
     'html.no-details ' + DETAILS + '[open] > ' + SUMMARY + ':before { content: "\u25bc"; }')


### PR DESCRIPTION
Add `display: block;` style to the `details` tag in order to ensure nested `details` tags are not all on the same line. This more closely matches the way they are displayed in browsers that natively understand them.